### PR TITLE
Add example for voice-based hot mic

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ You can reproduce their training by loading the config from their run. Simply ru
 python lerobot/scripts/train.py --config_path=lerobot/diffusion_pusht
 ```
 reproduces SOTA results for Diffusion Policy on the PushT task.
+### Hot microphone example
+
+A minimal voice interface is provided in [hotmic_speaklite.py](examples/hotmic_speaklite.py). It listens from the microphone, transcribes speech with Whisper and replies using the system text-to-speech.
+
+```bash
+python examples/hotmic_speaklite.py --play-sounds
+```
+
 
 ## Contribute
 

--- a/examples/hotmic_speaklite.py
+++ b/examples/hotmic_speaklite.py
@@ -1,0 +1,56 @@
+"""Hot microphone loop using Whisper STT and system text to speech.
+
+This example demonstrates a simple voice interface that listens from the
+microphone and replies using the `say` helper from :mod:`lerobot.common.utils`.
+Speech transcription relies on the ``speech_recognition`` package which can
+use the `whisper` model for offline recognition when installed.
+
+Usage::
+
+    python examples/hotmic_speaklite.py --play-sounds
+
+Press ``Ctrl+C`` to exit the loop.
+"""
+
+import argparse
+
+import speech_recognition as sr
+
+from lerobot.common.utils.utils import log_say
+
+
+def listen_once(play_sounds: bool = True) -> None:
+    """Listen from the microphone and speak back the transcript."""
+    recognizer = sr.Recognizer()
+    with sr.Microphone() as source:
+        log_say("Listening...", play_sounds)
+        audio = recognizer.listen(source)
+    try:
+        text = recognizer.recognize_whisper(audio)
+        log_say(f"You said: {text}", play_sounds)
+    except sr.UnknownValueError:
+        log_say("Could not understand audio.", play_sounds)
+    except sr.RequestError as exc:
+        log_say(f"STT error: {exc}", play_sounds)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Minimal hot microphone example")
+    parser.add_argument(
+        "--play-sounds",
+        action="store_true",
+        help="Speak responses using the system text-to-speech",
+    )
+    args = parser.parse_args()
+
+    log_say("Hotmic ready. Press Ctrl+C to stop.", args.play_sounds)
+    try:
+        while True:
+            listen_once(play_sounds=args.play_sounds)
+    except KeyboardInterrupt:
+        log_say("Stopping.", args.play_sounds)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `hotmic_speaklite.py` example for quick voice-based loop
- document running the hot microphone example in README

## Testing
- `pytest -k 'none' -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_b_68549b52f6b88331aff82d3f9ef2e535